### PR TITLE
Add AIRapGuide page

### DIFF
--- a/src/AIRapGuide.js
+++ b/src/AIRapGuide.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function AIRapGuide() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white">
+      <div className="text-center p-8">
+        <h1 className="text-4xl font-bold mb-4">AI Rap Guide</h1>
+        <p className="text-gray-300">This page is under construction.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import JandCLanguages from './JandCLanguages';
 import PodcastProposal from './PodcastProposal';
 import FounderService from './FounderService';
 import ProposalPage from './FounderBrandProgram';
+import AIRapGuide from './AIRapGuide';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -22,6 +23,7 @@ root.render(
         <Route path="/podcast-proposal" element={<PodcastProposal />} />
         <Route path="/founder-service" element={<FounderService />} />
         <Route path="/founder-brand-program" element={<ProposalPage />} />
+        <Route path="/airapguide" element={<AIRapGuide />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- add placeholder AI Rap Guide page component
- register airapguide route in React router

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bdda91c6a4832bb50cf1065e6d653b